### PR TITLE
check range of PICK before accessing stack

### DIFF
--- a/atlast-32/atlast.c
+++ b/atlast-32/atlast.c
@@ -1762,6 +1762,7 @@ prim P_over()                         /* Push copy of next to top of stack */
 prim P_pick()                         /* Copy indexed item from stack */
 {
     Sl(2);
+    Sl(2 + (unsigned int)S0);
     S0 = stk[-(2 + S0)];
 }
 
@@ -1792,7 +1793,7 @@ prim P_roll()                         /* Rotate N top stack items */
     stackitem i, j, t;
 
     Sl(1);
-    i = S0;
+    i = (unsigned int)S0;
     Pop;
     Sl(i + 1);
     t = stk[-(i + 1)];

--- a/atlast-64/atlast.c
+++ b/atlast-64/atlast.c
@@ -1747,6 +1747,7 @@ prim P_over()                         /* Push copy of next to top of stack */
 prim P_pick()                         /* Copy indexed item from stack */
 {
     Sl(2);
+    Sl(2 + (unsigned int)S0);
     S0 = stk[-(2 + S0)];
 }
 
@@ -1777,7 +1778,7 @@ prim P_roll()                         /* Rotate N top stack items */
     stackitem i, j, t;
 
     Sl(1);
-    i = S0;
+    i = (unsigned int)S0;
     Pop;
     Sl(i + 1);
     t = stk[-(i + 1)];


### PR DESCRIPTION
memcheck doesn't validate the range of PICK at all before accessing, so something trivial like
```
1 99999 pick
```
would segfault.  This change validates the argument before accessing the stack.   Also validates the argument to ROLL as unsigned before accessing, so that 
```
0 -99999 roll
```
is caught as underflow.